### PR TITLE
Support newer gleam versions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ import glisten
 
 pub fn main() {
   handler.func(fn(msg, state) {
-    assert Ok(_) = tcp.send(state.socket, bit_builder.from_bit_string(msg))
+    let assert Ok(_) = tcp.send(state.socket, bit_builder.from_bit_string(msg))
     actor.Continue(state)
   })
   |> acceptor.new_pool
@@ -58,7 +58,7 @@ import glisten/ssl
 
 pub fn main() {
   handler.func(fn(msg, state) {
-    assert Ok(_) = ssl.send(state.socket, bit_builder.from_bit_string(msg))
+    let assert Ok(_) = ssl.send(state.socket, bit_builder.from_bit_string(msg))
     actor.Continue(state)
   })
   |> acceptor.new_pool
@@ -88,10 +88,10 @@ pub fn main() {
   // This function is omitted for brevity.  It simply manages a
   // `gleam/set.{Set}` of `Sender(HandlerMessage)`s that "broadcast" the
   // connect/disconnect events to all clients.
-  assert Ok(connections) = start_connection_actor()
+  let assert Ok(connections) = start_connection_actor()
 
   handler.func(fn(msg, state) {
-    assert Ok(_) = tcp.send(state.socket, bit_builder.from_bit_string(msg))
+    let assert Ok(_) = tcp.send(state.socket, bit_builder.from_bit_string(msg))
     actor.Continue(state)
   })
   |> acceptor.new_pool

--- a/gleam.toml
+++ b/gleam.toml
@@ -5,7 +5,7 @@ licences = ["Apache-2.0"]
 repository = { type = "github", user = "rawhat", repo = "glisten" }
 
 [dependencies]
-gleam_stdlib = "~> 0.22"
+gleam_stdlib = "~> 0.26"
 gleam_otp = "~> 0.5"
 gleam_erlang = "~> 0.15"
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -5,7 +5,7 @@ licences = ["Apache-2.0"]
 repository = { type = "github", user = "rawhat", repo = "glisten" }
 
 [dependencies]
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleam_otp = "~> 0.5"
 gleam_erlang = "~> 0.15"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.17.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "BAAA84F5BCC4477E809BA3E03BB3009A3894A6544C1511626C44408E39DB2AE6" },
-  { name = "gleam_otp", version = "0.5.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_erlang"], otp_app = "gleam_otp", source = "hex", outer_checksum = "24B88BF1D5B8DEC2525C00ECB65B96D2FD4DC66D8B2BB4D7AD4D12B2CE2A9988" },
-  { name = "gleam_stdlib", version = "0.26.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "6221F9D7A08B6D6DBCDD567B2BB7C4B2A7BBF4C04C6110757BE04635143BDEC8" },
-  { name = "gleeunit", version = "0.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "37F8904B6844A99A2C041E56B2E08D464AC2529E68EB0A3FA4AD93745E0A3A59" },
+  { name = "gleam_erlang", version = "0.18.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "C69F59D086AD50B80DE294FB0963550630971C9DC04E92B1F7AEEDD2C0BE226C" },
+  { name = "gleam_otp", version = "0.5.2", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "24B88BF1D5B8DEC2525C00ECB65B96D2FD4DC66D8B2BB4D7AD4D12B2CE2A9988" },
+  { name = "gleam_stdlib", version = "0.28.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1BB6A3E53F7576B9F5C4E5D4AE16487E526BE383B03CBF4068C7DFC77CF38A1C" },
+  { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]
 gleam_erlang = "~> 0.15"
 gleam_otp = "~> 0.5"
-gleam_stdlib = "~> 0.22"
+gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.6"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,7 @@
 
 packages = [
   { name = "gleam_erlang", version = "0.18.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "C69F59D086AD50B80DE294FB0963550630971C9DC04E92B1F7AEEDD2C0BE226C" },
-  { name = "gleam_otp", version = "0.5.2", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "24B88BF1D5B8DEC2525C00ECB65B96D2FD4DC66D8B2BB4D7AD4D12B2CE2A9988" },
+  { name = "gleam_otp", version = "0.5.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_erlang"], otp_app = "gleam_otp", source = "hex", outer_checksum = "24B88BF1D5B8DEC2525C00ECB65B96D2FD4DC66D8B2BB4D7AD4D12B2CE2A9988" },
   { name = "gleam_stdlib", version = "0.28.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1BB6A3E53F7576B9F5C4E5D4AE16487E526BE383B03CBF4068C7DFC77CF38A1C" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
@@ -11,5 +11,5 @@ packages = [
 [requirements]
 gleam_erlang = "~> 0.15"
 gleam_otp = "~> 0.5"
-gleam_stdlib = "~> 0.26"
+gleam_stdlib = "~> 0.27"
 gleeunit = "~> 0.6"

--- a/src/glisten.gleam
+++ b/src/glisten.gleam
@@ -24,7 +24,7 @@ pub fn serve(
   port: Int,
   with_pool: fn(ListenSocket) -> Pool(data),
 ) -> Result(Nil, StartError) {
-  try _ =
+  use _ <- result.then(
     port
     |> tcp.listen([])
     |> result.map_error(fn(err) {
@@ -45,7 +45,8 @@ pub fn serve(
           actor.InitCrashed(reason) -> AcceptorCrashed(reason)
         }
       })
-    })
+    }),
+  )
 
   Ok(Nil)
 }
@@ -61,8 +62,8 @@ pub fn serve_ssl(
   keyfile keyfile: String,
   with_pool with_pool: fn(ListenSocket) -> Pool(data),
 ) -> Result(Nil, StartError) {
-  assert Ok(_nil) = start_ssl()
-  try _ =
+  let assert Ok(_nil) = start_ssl()
+  use _ <- result.then(
     port
     |> ssl.listen([
       Certfile(certfile),
@@ -87,7 +88,8 @@ pub fn serve_ssl(
           actor.InitCrashed(reason) -> AcceptorCrashed(reason)
         }
       })
-    })
+    }),
+  )
 
   Ok(Nil)
 }

--- a/src/glisten/acceptor.gleam
+++ b/src/glisten/acceptor.gleam
@@ -51,10 +51,11 @@ pub fn start(
       case msg {
         AcceptConnection(listener) -> {
           let res = {
-            try sock =
+            use sock <- result.then(
               state.transport.accept(listener)
-              |> result.replace_error(AcceptError)
-            try start =
+              |> result.replace_error(AcceptError),
+            )
+            use start <- result.then(
               Handler(
                 sock,
                 pool.initial_data,
@@ -64,7 +65,8 @@ pub fn start(
                 pool.transport,
               )
               |> handler.start
-              |> result.replace_error(HandlerError)
+              |> result.replace_error(HandlerError),
+            )
             sock
             |> state.transport.controlling_process(process.subject_owner(start))
             |> result.replace_error(ControlError)

--- a/src/glisten/handler.gleam
+++ b/src/glisten/handler.gleam
@@ -113,7 +113,7 @@ pub fn start(
         msg ->
           case handler.loop(msg, state) {
             actor.Continue(next_state) -> {
-              assert Ok(Nil) =
+              let assert Ok(Nil) =
                 state.transport.set_opts(
                   state.socket,
                   [options.ActiveMode(options.Once)],

--- a/src/glisten/ssl.gleam
+++ b/src/glisten/ssl.gleam
@@ -57,7 +57,7 @@ pub external fn do_shutdown(
   "ssl_ffi" "shutdown"
 
 pub fn shutdown(socket: Socket) -> Result(Nil, SocketReason) {
-  assert Ok(write) = atom.from_string("write")
+  let assert Ok(write) = atom.from_string("write")
   do_shutdown(socket, write)
 }
 

--- a/src/glisten/tcp.gleam
+++ b/src/glisten/tcp.gleam
@@ -60,7 +60,7 @@ pub external fn do_shutdown(
   "tcp_ffi" "shutdown"
 
 pub fn shutdown(socket: Socket) -> Result(Nil, SocketReason) {
-  assert Ok(write) = atom.from_string("write")
+  let assert Ok(write) = atom.from_string("write")
   do_shutdown(socket, write)
 }
 

--- a/test/glisten_test.gleam
+++ b/test/glisten_test.gleam
@@ -25,12 +25,12 @@ pub fn it_echoes_messages_test() {
   let _server =
     process.start(
       fn() {
-        assert Nil = process.send(client_subject, Connected)
-        assert Ok(listener) =
+        let assert Nil = process.send(client_subject, Connected)
+        let assert Ok(listener) =
           tcp.listen(9999, [options.ActiveMode(options.Passive)])
-        assert Ok(socket) = tcp.accept(listener)
+        let assert Ok(socket) = tcp.accept(listener)
         let loop = fn() {
-          assert Ok(msg) = tcp.receive_timeout(socket, 0, 200)
+          let assert Ok(msg) = tcp.receive_timeout(socket, 0, 200)
           process.send(client_subject, Response(msg))
         }
         loop()
@@ -38,21 +38,22 @@ pub fn it_echoes_messages_test() {
       False,
     )
 
-  assert Ok(Connected) = process.receive(client_subject, 200)
+  let assert Ok(Connected) = process.receive(client_subject, 200)
 
   let client = tcp_client.connect()
-  assert Ok(_) =
+  let assert Ok(_) =
     tcp.send(client, bit_builder.from_bit_string(<<"hi mom":utf8>>))
-  assert Ok(Response(resp)) = process.receive(client_subject, 200)
+  let assert Ok(Response(resp)) = process.receive(client_subject, 200)
 
   should.equal(resp, <<"hi mom":utf8>>)
 }
 
 pub fn it_accepts_from_the_pool_test() {
   let client_sender = process.new_subject()
-  assert Ok(Nil) =
+  let assert Ok(Nil) =
     handler.func(fn(msg, state) {
-      assert Ok(_) = tcp.send(state.socket, bit_builder.from_bit_string(msg))
+      let assert Ok(_) =
+        tcp.send(state.socket, bit_builder.from_bit_string(msg))
       actor.Continue(state)
     })
     |> acceptor.new_pool
@@ -68,15 +69,16 @@ pub fn it_accepts_from_the_pool_test() {
             dynamic.unsafe_coerce,
           )
         let client = tcp_client.connect()
-        assert Ok(_) =
+        let assert Ok(_) =
           tcp.send(client, bit_builder.from_bit_string(<<"hi mom":utf8>>))
-        assert Ok(#(_tcp, _port, msg)) = process.select(client_selector, 200)
+        let assert Ok(#(_tcp, _port, msg)) =
+          process.select(client_selector, 200)
         process.send(client_sender, msg)
       },
       False,
     )
 
-  assert Ok(msg) = process.receive(client_sender, 200)
+  let assert Ok(msg) = process.receive(client_sender, 200)
 
   should.equal(msg, <<"hi mom":utf8>>)
 }

--- a/test/tcp_client.gleam
+++ b/test/tcp_client.gleam
@@ -11,7 +11,7 @@ external fn tcp_connect(
   "gen_tcp" "connect"
 
 pub fn connect() -> Socket {
-  assert Ok(client) =
+  let assert Ok(client) =
     tcp_connect(
       charlist.from_string("localhost"),
       9999,


### PR DESCRIPTION
This PR supports newer gleam versions
- Update dependencies (sorry its bloated for this PR! couldn't get it to compile otherwise)
- Replace `assert Ok(_)` with `let assert Ok(_)`
- Remove duplicate imports
- Use `result.then` instead of `try`