### PR TITLE
Fix typo in Message docs

### DIFF
--- a/src/glisten.gleam
+++ b/src/glisten.gleam
@@ -29,7 +29,7 @@ pub type StartError {
   SystemError(SocketReason)
 }
 
-/// Your provided loop function with receive these message types as the
+/// Your provided loop function will receive these message types as the
 /// first argument.
 pub type Message(user_message) {
   /// These are messages received from the socket


### PR DESCRIPTION
Noticed a small typo while reading the docs here https://hexdocs.pm/glisten/6.0.0/glisten.html#Message.