### PR TITLE
Fix formatting of non-loopback IPv6 addresses

### DIFF
--- a/test/glisten_test.gleam
+++ b/test/glisten_test.gleam
@@ -1,11 +1,12 @@
 import gleam/bytes_builder
 import gleam/dynamic
 import gleam/erlang/process
+import gleam/list
 import gleam/option.{None}
 import gleam/otp/actor
 import gleeunit
 import gleeunit/should
-import glisten.{Packet}
+import glisten.{IpV6, Packet}
 import glisten/socket/options
 import glisten/tcp
 import tcp_client
@@ -80,4 +81,18 @@ pub fn it_accepts_from_the_pool_test() {
   let assert Ok(msg) = process.receive(client_sender, 200)
 
   should.equal(msg, <<"hi mom":utf8>>)
+}
+
+pub fn ip_address_to_string_test() {
+  use #(ip, expected) <- list.each([
+    #(IpV6(0, 0, 0, 0, 0, 0, 0, 1), "::1"),
+    #(IpV6(0, 0, 0, 0, 0, 0, 0, 0), "::"),
+    #(IpV6(0x2001, 0xdb8, 0, 0, 1, 0, 0, 0), "2001:db8:0:0:1::"),
+    #(IpV6(0x2001, 0xdb8, 1, 1, 1, 1, 0, 1), "2001:db8:1:1:1:1:0:1"),
+    #(IpV6(0x2001, 0xdb8, 0, 0, 1, 0, 0, 1), "2001:db8::1:0:0:1"),
+    #(IpV6(0x2001, 0xdb8, 0, 0, 0, 0, 2, 1), "2001:db8::2:1"),
+  ])
+
+  glisten.ip_address_to_string(ip)
+  |> should.equal(expected)
 }


### PR DESCRIPTION
Hi,

Currently the `ip_address_to_string` function formats all IPv6 addresses (except loopback) to the form `8193::3512::0::0::0::0::0::1` (which is invalid) instead of one of the following representations:
- `2001:db8:0:0:0:0:0:1`
- `2001:0db8:0000:0000:0000:0000:0000:0001`
- `2001:db8::1` (IETF’s recommended canonical format).

I encountered the issue using Mist while binding to a specific interface. It uses `ip_address_to_string` to print `Listening on http://[0::0::0::0::0::0::0::0]:8080` in the console on startup, which is obviously not a valid URL in this instance.

This implement RFC 5952 canonical format. Previous loopback short-hand is the default and not a special case anymore.

Please tell me if the formatting logic would be better placed in an internal module or if it’s fine as-is in the root module.