### PR TITLE
Correct version requirement for stdlib

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -6,7 +6,7 @@ repository = { type = "github", user = "rawhat", repo = "glisten" }
 gleam = ">= 1.1.0"
 
 [dependencies]
-gleam_stdlib = ">= 0.39.0 and < 1.0.0"
+gleam_stdlib = ">= 0.44.0 and < 1.0.0"
 gleam_otp = ">= 0.10.0 and < 1.0.0"
 gleam_erlang = ">= 0.25.0 and < 1.0.0"
 telemetry = ">= 1.2.1 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,9 +2,9 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.30.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "760618870AE4A497B10C73548E6E44F43B76292A54F0207B3771CBB599C675B4" },
+  { name = "gleam_erlang", version = "0.32.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "B18643083A0117AC5CFD0C1AEEBE5469071895ECFA426DCC26517A07F6AD9948" },
   { name = "gleam_otp", version = "0.14.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "5A8CE8DBD01C29403390A7BD5C0A63D26F865C83173CF9708E6E827E53159C65" },
-  { name = "gleam_stdlib", version = "0.42.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CF1C19DAB36C82EF6A8C60CF38884825641EBEA45E5495760D642C2ABB266192" },
+  { name = "gleam_stdlib", version = "0.45.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "206FCE1A76974AECFC55AEBCD0217D59EDE4E408C016E2CFCCC8FF51278F186E" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "logging", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "1098FBF10B54B44C2C7FDF0B01C1253CAFACDACABEFB4B0D027803246753E06D" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
@@ -13,7 +13,7 @@ packages = [
 [requirements]
 gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
 gleam_otp = { version = ">= 0.10.0 and < 1.0.0" }
-gleam_stdlib = { version = ">= 0.39.0 and < 1.0.0" }
+gleam_stdlib = { version = ">= 0.44.0 and < 1.0.0" }
 gleeunit = { version = "~> 1.0" }
 logging = { version = ">= 1.3.0 and < 2.0.0" }
 telemetry = { version = ">= 1.2.1 and < 2.0.0" }

--- a/src/glisten.gleam
+++ b/src/glisten.gleam
@@ -126,7 +126,7 @@ pub fn get_client_info(
   |> result.map(fn(pair) { ConnectionInfo(pair.1, convert_ip_address(pair.0)) })
 }
 
-/// Sends a BytesBuilder message over the socket using the active transport
+/// Sends a BytesTree message over the socket using the active transport
 pub fn send(
   conn: Connection(user_message),
   msg: BytesTree,


### PR DESCRIPTION
The previous one would fail to compile with the lower version permitted.

It would also be really useful to have a release of this! Then we can update the stdlib to remove the deprecation warnings. 🙏