### PR TITLE
Update examples & readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ gleam add glisten gleam_erlang gleam_otp
 Then place this code in `src/<your_project>.gleam`:
 
 ```gleam
-import gleam/bytes_builder
+import gleam/bytes_tree
 import gleam/erlang/process
 import gleam/option.{None}
 import gleam/otp/actor
@@ -30,7 +30,7 @@ pub fn main() {
   let assert Ok(_) =
     glisten.handler(fn(_conn) { #(Nil, None) }, fn(msg, state, conn) {
       let assert Packet(msg) = msg
-      let assert Ok(_) = glisten.send(conn, bytes_builder.from_bit_array(msg))
+      let assert Ok(_) = glisten.send(conn, bytes_tree.from_bit_array(msg))
       actor.continue(state)
     })
     // NOTE:  By default, `glisten` will listen on the loopback interface.  If

--- a/examples/echo_server/manifest.toml
+++ b/examples/echo_server/manifest.toml
@@ -2,13 +2,13 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
-  { name = "gleam_stdlib", version = "0.39.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2D7DE885A6EA7F1D5015D1698920C9BAF7241102836CE0C3837A4F160128A9C4" },
+  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
+  { name = "gleam_otp", version = "0.16.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "FA0EB761339749B4E82D63016C6A18C4E6662DA05BAB6F1346F9AF2E679E301A" },
+  { name = "gleam_stdlib", version = "0.52.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "50703862DF26453B277688FFCDBE9DD4AC45B3BD9742C0B370DB62BC1629A07D" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
-  { name = "glisten", version = "4.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], source = "local", path = "../.." },
+  { name = "glisten", version = "7.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], source = "local", path = "../.." },
   { name = "logging", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "1098FBF10B54B44C2C7FDF0B01C1253CAFACDACABEFB4B0D027803246753E06D" },
-  { name = "telemetry", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "DAD9CE9D8EFFC621708F99EAC538EF1CBE05D6A874DD741DE2E689C47FEAFED5" },
+  { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
 ]
 
 [requirements]

--- a/examples/echo_server/src/echo_server.gleam
+++ b/examples/echo_server/src/echo_server.gleam
@@ -1,4 +1,4 @@
-import gleam/bytes_builder
+import gleam/bytes_tree
 import gleam/dict.{type Dict}
 import gleam/erlang/atom.{type Atom}
 import gleam/erlang/process
@@ -33,7 +33,7 @@ pub fn main() {
           <> int.to_string(info.port),
       )
       let assert Packet(msg) = msg
-      let assert Ok(_) = glisten.send(conn, bytes_builder.from_bit_array(msg))
+      let assert Ok(_) = glisten.send(conn, bytes_tree.from_bit_array(msg))
       actor.continue(state)
     })
     |> glisten.bind("localhost")

--- a/examples/echo_ssl/src/echo_server.gleam
+++ b/examples/echo_ssl/src/echo_server.gleam
@@ -1,4 +1,4 @@
-import gleam/bytes_builder
+import gleam/bytes_tree
 import gleam/dict.{type Dict}
 import gleam/erlang/atom.{type Atom}
 import gleam/erlang/process
@@ -33,7 +33,7 @@ pub fn main() {
           <> int.to_string(info.port),
       )
       let assert Packet(msg) = msg
-      let assert Ok(_) = glisten.send(conn, bytes_builder.from_bit_array(msg))
+      let assert Ok(_) = glisten.send(conn, bytes_tree.from_bit_array(msg))
       actor.continue(state)
     })
     |> glisten.start_ssl_server(


### PR DESCRIPTION
- examples/echo_server uses the deprecated bytes_builder module, updated to use gleam/bytes_tree module
- example code in the readme uses bytes_builder, updated with bytes_tree