### PR TITLE
Bump `gleam_stdlib` version requirement to >= 0.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Require `stdlib` >= 0.50
+
 # v7.0.1
 
 - Migrate to `gleam/dynamic/decode` API

--- a/gleam.toml
+++ b/gleam.toml
@@ -9,7 +9,7 @@ gleam = ">= 1.4.0"
 extra_applications = ["ssl"]
 
 [dependencies]
-gleam_stdlib = ">= 0.44.0 and < 1.0.0"
+gleam_stdlib = ">= 0.50.0 and < 1.0.0"
 gleam_otp = ">= 0.10.0 and < 1.0.0"
 gleam_erlang = ">= 0.25.0 and < 1.0.0"
 telemetry = ">= 1.2.1 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -13,7 +13,7 @@ packages = [
 [requirements]
 gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
 gleam_otp = { version = ">= 0.10.0 and < 1.0.0" }
-gleam_stdlib = { version = ">= 0.44.0 and < 1.0.0" }
+gleam_stdlib = { version = ">= 0.50.0 and < 1.0.0" }
 gleeunit = { version = "~> 1.0" }
 logging = { version = ">= 1.3.0 and < 2.0.0" }
 telemetry = { version = ">= 1.2.1 and < 2.0.0" }


### PR DESCRIPTION
This fixes a backward compatibility break introduced in 7.0.1 by the migration to `decode` API, which is not in `stdlib` yet between 0.44 to 0.49.

Should this be a 7.1.0? It’s seems weird to bump a dependency on a patch level release.

The error on `stdlib` 0.47:
```console
  Compiling glisten
error: Unknown module
  ┌─ <redacted>/build/packages/glisten/src/glisten/socket/options.gleam:3:1
  │
3 │ import gleam/dynamic/decode
  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^

No module has been found with the name `gleam/dynamic/decode`.

error: Unknown module
   ┌─ <redacted>/build/packages/glisten/src/glisten/socket/options.gleam:47:16
   │
47 │     use opt <- decode.field(0, decode.dynamic)
   │                ^^^^^^

No module has been found with the name `decode`.
Hint: Did you mean to import `decode`?

error: Unknown module
   ┌─ <redacted>/build/packages/glisten/src/glisten/socket/options.gleam:47:32
   │
47 │     use opt <- decode.field(0, decode.dynamic)
   │                                ^^^^^^

No module has been found with the name `decode`.
Hint: Did you mean to import `decode`?

error: Unknown module
   ┌─ <redacted>/build/packages/glisten/src/glisten/socket/options.gleam:48:18
   │
48 │     use value <- decode.field(1, decode.dynamic)
   │                  ^^^^^^

No module has been found with the name `decode`.
Hint: Did you mean to import `decode`?

error: Unknown module
   ┌─ <redacted>/build/packages/glisten/src/glisten/socket/options.gleam:48:34
   │
48 │     use value <- decode.field(1, decode.dynamic)
   │                                  ^^^^^^

No module has been found with the name `decode`.
Hint: Did you mean to import `decode`?

error: Unknown module
   ┌─ <redacted>/build/packages/glisten/src/glisten/socket/options.gleam:49:5
   │
49 │     decode.success(#(opt, value))
   │     ^^^^^^

No module has been found with the name `decode`.

error: Unknown module
   ┌─ <redacted>/build/packages/glisten/src/glisten/socket/options.gleam:73:22
   │
73 │   |> list.filter_map(decode.run(_, opt_decoder))
   │                      ^^^^^^

No module has been found with the name `decode`.
```