### PR TITLE
fix: rename to get_connection_info

### DIFF
--- a/examples/echo_server/src/echo_server.gleam
+++ b/examples/echo_server/src/echo_server.gleam
@@ -23,7 +23,7 @@ pub fn main() {
 
   let assert Ok(_server) =
     glisten.new(fn(_conn) { #(Nil, None) }, fn(state, msg, conn) {
-      let assert Ok(info) = glisten.get_client_info(conn)
+      let assert Ok(info) = glisten.get_connection_info(conn)
       logging.log(
         logging.Info,
         "Client connected at "

--- a/examples/echo_ssl/src/echo_server.gleam
+++ b/examples/echo_ssl/src/echo_server.gleam
@@ -23,7 +23,7 @@ pub fn main() {
 
   let assert Ok(_server) =
     glisten.new(fn(_conn) { #(Nil, None) }, fn(state, msg, conn) {
-      let assert Ok(info) = glisten.get_client_info(conn)
+      let assert Ok(info) = glisten.get_connection_info(conn)
       logging.log(
         logging.Info,
         "Client connected at "

--- a/src/glisten.gleam
+++ b/src/glisten.gleam
@@ -123,7 +123,7 @@ fn ipv6_zeros(fields, pos, len, max_start, max_len) -> Result(#(Int, Int), Nil) 
 /// Tries to read the IP address and port of a connected client.  It will
 /// return valid IPv4 or IPv6 addresses, attempting to return the most relevant
 /// one for the client.
-pub fn get_client_info(
+pub fn get_connection_info(
   conn: Connection(user_message),
 ) -> Result(ConnectionInfo, Nil) {
   transport.peername(conn.transport, conn.socket)


### PR DESCRIPTION
# Original Issue
https://github.com/rawhat/glisten/issues/32

## Summary
1. Renamed `glisten.get_client_info(Connection) -> ConnectionInfo`  to `glisten.get_connection_info()`.