### PR TITLE
Support in-memory PEM and DER certificates for TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - support in-memory `PEM` and `DER` certificates for TLS
+- support mTLS
 
 # v9.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- support in-memory `PEM` and `DER` certificates for TLS
+
 # v9.0.1
 
 - Bump `stdlib` to `>=1.0.0`

--- a/src/glisten.gleam
+++ b/src/glisten.gleam
@@ -209,6 +209,7 @@ pub opaque type Builder(state, user_message) {
     http2_support: Bool,
     ipv6_support: Bool,
     tls_options: Option(options.TlsCerts),
+    client_verification: Option(CaCert),
     listener_name: Option(process.Name(listener.Message)),
     connection_factory_name: Option(
       process.Name(
@@ -287,6 +288,7 @@ pub fn new(
     http2_support: False,
     ipv6_support: False,
     tls_options: None,
+    client_verification: None,
     listener_name: None,
     connection_factory_name: None,
     active_state: options.Once,
@@ -356,7 +358,7 @@ pub fn with_tls(
   Builder(..builder, tls_options: Some(options.CertKeyFiles(cert, key)))
 }
 
-/// To use TLS, provide in-memory PEM_encoded certificate and key data.
+/// To use TLS, provide in-memory PEM-encoded certificate and key data.
 pub fn with_tls_pem(
   builder: Builder(state, user_message),
   cert cert: BitArray,
@@ -374,6 +376,23 @@ pub fn with_tls_der(
   key key: BitArray,
 ) -> Builder(state, user_message) {
   Builder(..builder, tls_options: Some(options.CertKeyDer(cert, key_type, key)))
+}
+
+/// Specifies the CA certificate source for verifying client certificates.
+pub type CaCert {
+  /// Path to a PEM file containing the CA certificate.
+  CaCertFile(path: String)
+  /// In-memory DER-encoded CA certificate.
+  CaCertData(certs: List(BitArray))
+}
+
+/// Enables mTLS by requiring clients to present a certificate signed by the 
+/// provided CA. Connections without a valid certificate are rejected.
+pub fn with_client_verification(
+  builder: Builder(state, user_message),
+  ca_cert: CaCert,
+) -> Builder(state, user_message) {
+  Builder(..builder, client_verification: Some(ca_cert))
 }
 
 /// Set the server's `ActiveState` for flow control of received packets.
@@ -436,6 +455,19 @@ pub fn start(
       Some(_), True -> [options.AlpnPreferredProtocols(["h2", "http/1.1"])]
       Some(_), False -> [options.AlpnPreferredProtocols(["http/1.1"])]
       None, _ -> []
+    })
+    |> list.append(case builder.client_verification {
+      Some(CaCertFile(path)) -> [
+        options.Verify(options.VerifyPeer),
+        options.CaCertFile(path),
+        options.FailIfNoPeerCert(True),
+      ]
+      Some(CaCertData(certs)) -> [
+        options.Verify(options.VerifyPeer),
+        options.CaCerts(certs),
+        options.FailIfNoPeerCert(True),
+      ]
+      None -> []
     })
 
   let transport = case builder.tls_options {

--- a/src/glisten.gleam
+++ b/src/glisten.gleam
@@ -356,6 +356,26 @@ pub fn with_tls(
   Builder(..builder, tls_options: Some(options.CertKeyFiles(cert, key)))
 }
 
+/// To use TLS, provide in-memory PEM_encoded certificate and key data.
+pub fn with_tls_pem(
+  builder: Builder(state, user_message),
+  cert cert: BitArray,
+  key key: BitArray,
+) -> Builder(state, user_message) {
+  Builder(..builder, tls_options: Some(options.CertKeyPem(cert, key)))
+}
+
+/// To use TLS, provide in-memory DER-encoded certificate and key data. The key 
+/// type must match the encoding of the provided key binary.
+pub fn with_tls_der(
+  builder: Builder(state, user_message),
+  cert cert: BitArray,
+  key_type key_type: options.TlsKeyType,
+  key key: BitArray,
+) -> Builder(state, user_message) {
+  Builder(..builder, tls_options: Some(options.CertKeyDer(cert, key_type, key)))
+}
+
 /// Set the server's `ActiveState` for flow control of received packets.
 /// Default is `Once`. Allowed are `Once`, `Active` and `Count(n)` where n > 1.
 pub fn with_active_state(

--- a/src/glisten/socket/options.gleam
+++ b/src/glisten/socket/options.gleam
@@ -21,8 +21,27 @@ pub type Interface {
   Loopback
 }
 
+/// Specifies how TLS certificates and keys are provided to the server
 pub type TlsCerts {
   CertKeyFiles(certfile: String, keyfile: String)
+  /// In-memory PEM-encoded certificate and key.
+  CertKeyPem(cert: BitArray, key: BitArray)
+  /// In-memory DER-encoded certificate and key. The key type must be provided 
+  /// explicitly since it is not embedded in the binary.
+  CertKeyDer(cert: BitArray, key_type: TlsKeyType, key: BitArray)
+}
+
+/// The private key encoding type, required when providing DER-encoded 
+/// certificate and key
+pub type TlsKeyType {
+  /// Traditional RSA key.
+  RsaPrivateKey
+  /// Elliptic curve key.
+  EcPrivateKey
+  /// DSA key.
+  DsaPrivateKey
+  /// PKCS#8 key.
+  PrivateKeyInfo
 }
 
 /// Options for the TCP socket

--- a/src/glisten/socket/options.gleam
+++ b/src/glisten/socket/options.gleam
@@ -67,6 +67,23 @@ pub type TcpOption {
   Ipv6
   Buffer(Int)
   Ip(Interface)
+  /// Controls client certificate verification.
+  Verify(VerifyMode)
+  /// Path to a PEM file containing CA certificate for client verification.
+  CaCertFile(String)
+  /// In-memory DER-encoded CA certificate for client verification.
+  CaCerts(List(BitArray))
+  /// When `True`, rejects connections that do not present a client certificate.  
+  /// Default False.
+  FailIfNoPeerCert(Bool)
+}
+
+/// Controls whether the server verifies the client's certificate
+pub type VerifyMode {
+  /// No client certificate is requested.
+  VerifyNone
+  /// Client must present a certificate.
+  VerifyPeer
 }
 
 pub type ErlangTcpOption

--- a/src/glisten_ffi.erl
+++ b/src/glisten_ffi.erl
@@ -44,6 +44,11 @@ to_erl_tcp_option({cert_key_config, {cert_key_pem, Cert, Key}}) ->
 to_erl_tcp_option({cert_key_config, {cert_key_der, Cert, KeyType, Key}}) ->
   ErlKeyType = key_type_to_erl(KeyType),
   {certs_keys, [#{cert => [Cert], key => {ErlKeyType, Key}}]};
+to_erl_tcp_option({verify, verify_peer}) -> {verify, verify_peer};
+to_erl_tcp_option({verify, verify_none}) -> {verify, verify_none};
+to_erl_tcp_option({ca_cert_file, Path}) -> {cacertfile, Path};
+to_erl_tcp_option({ca_certs, Certs}) -> {cacerts, Certs};
+to_erl_tcp_option({fail_if_no_peer_cert, V}) -> {fail_if_no_peer_cert, V};
 to_erl_tcp_option(Other) -> Other.
 
 key_type_to_erl(rsa_private_key)  -> 'RSAPrivateKey';

--- a/src/glisten_ffi.erl
+++ b/src/glisten_ffi.erl
@@ -37,7 +37,19 @@ to_erl_tcp_option({ip, loopback}) -> {ip, loopback};
 to_erl_tcp_option(ipv6) -> inet6;
 to_erl_tcp_option({cert_key_config, {cert_key_files, CertFile, KeyFile}}) ->
   {certs_keys, [#{certfile => CertFile, keyfile => KeyFile}]};
+to_erl_tcp_option({cert_key_config, {cert_key_pem, Cert, Key}}) ->
+  [{_, DerCert, _}|_] = public_key:pem_decode(Cert),
+  [{KeyType, DerKey, _}|_] = public_key:pem_decode(Key),
+  {certs_keys, [#{cert => [DerCert], key => {KeyType, DerKey}}]};
+to_erl_tcp_option({cert_key_config, {cert_key_der, Cert, KeyType, Key}}) ->
+  ErlKeyType = key_type_to_erl(KeyType),
+  {certs_keys, [#{cert => [Cert], key => {ErlKeyType, Key}}]};
 to_erl_tcp_option(Other) -> Other.
+
+key_type_to_erl(rsa_private_key)  -> 'RSAPrivateKey';
+key_type_to_erl(ec_private_key)   -> 'ECPrivateKey';
+key_type_to_erl(dsa_private_key)  -> 'DSAPrivateKey';
+key_type_to_erl(private_key_info) -> 'PrivateKeyInfo'.
 
 merge_type_list(Original, Override) ->
   NewKeys = get_type_keys(Override),


### PR DESCRIPTION
Closing #44

This PR adds in-memory support for TLS certificates and keys. The new API exposes all the popular options, at least the ones I could think of. This should be a good starting point. The function names or documentation lines can be tweaked a little as I am not sure if they are clean enough :D

I tested the new API with self-signed certificates. For `with_tls_pem`:
```bash
> openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes -subj "/CN=localhost"
```
And for `with_tls_dem`:
```bash
> openssl genpkey -algorithm RSA -out key.der -outform DER
> openssl req -new -key key.der -keyform DER -x509 -days 365 -out cert.der -outform DER -subj "/CN=localhost"
```

Simple example:
```bash
> echo "hello" | openssl s_client -connect localhost:8443

Connecting to 127.0.0.1
CONNECTED(00000003)
Can't use SSL_get_servername
depth=0 CN=localhost
verify error:num=18:self-signed certificate
verify return:1
depth=0 CN=localhost
verify return:1
---
Certificate chain
 0 s:CN=localhost
   i:CN=localhost
   a:PKEY: RSA, 2048 (bit); sigalg: sha256WithRSAEncryption
   v:NotBefore: Apr 20 07:47:02 2026 GMT; NotAfter: Apr 20 07:47:02 2027 GMT
---
Server certificate
-----BEGIN CERTIFICATE-----
MIIDCTCCAfGgAwIBAgIUe+41ip9Hj6ahOpzcQA3T900x/G8wDQYJKoZIhvcNAQEL
BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDQyMDA3NDcwMloXDTI3MDQy
MDA3NDcwMlowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
AAOCAQ8AMIIBCgKCAQEArvXmJapKKT4HejrhguwHVopF8hqOFFwEfNyKkWlOiCp4
Mvmigcfe07OC+e7jt/XlIcQJ4FpmcrGxeoUGKat6WcsS/CeGH2qiVrV/vV0s+EGl
YebnuVcxwWP+b7QKW+RekpvOOtByfIpwDXx2DYB0HF3cYf5CuN/U4kLaIs7uyfqt
DS3rNLbvkzOIR5ukkqWdWts+SOrQ0858QvkQ6QJKUM8UeBVn35ipleUAoWZk0h0R
JKRvA5axUCI8vdLeFyfz9/4/Adfa4PwKfSGHhnTKBOF0hfFJTm/6MD0hOsTm6ooX
lCanNLZwbuS4lipRVvgBizgG0SE8OH9MGjyOSXt1zQIDAQABo1MwUTAdBgNVHQ4E
FgQUXvGN8ITlzp4hPKwCXO6MGEBSRZcwHwYDVR0jBBgwFoAUXvGN8ITlzp4hPKwC
XO6MGEBSRZcwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAJJIk
qnCdfWVyGeNQZylWPmrHIUI5oC28+55c9rXSW9/i/13u54yMYMFE/GzjmzF43XH8
AaIGPhyvnpNnT1JryFuLKrWrnsMXT9T4v31qw/ywUwwsRPaOzuwXAvh3iilDe/M9
8lXMaJNl20gp6fjQ5+FLGtGvYiyG+QUA56jFKkUfOZTaHhClpNqfsrww65U/GG2D
L/yXL4YoYxqWa0eHFAixo0E4o1IkOl/e4tTg9YT9TQ9CbnoseUAWuwuHrrebBWFK
nz8Ru9qL7sk0yJ7WJhURYNGV/8fhj3cLp2/FDMwnEguH+14cq2JdK7S0uDfKbdbI
CG+DGF7I7MwJLJilNg==
-----END CERTIFICATE-----
subject=CN=localhost
issuer=CN=localhost
---
No client certificate CA names sent
Peer signing digest: SHA256
Peer signature type: rsa_pss_rsae_sha256
Peer Temp Key: X25519, 253 bits
---
SSL handshake has read 1337 bytes and written 1602 bytes
Verification error: self-signed certificate
---
New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
Protocol: TLSv1.3
Server public key is 2048 bit
This TLS version forbids renegotiation.
Compression: NONE
Expansion: NONE
No ALPN negotiated
Early data was not sent
Verify return code: 18 (self-signed certificate)
---
DONE
```