### PR TITLE
Add functions for TCP peeking

### DIFF
--- a/src/glisten/tcp.gleam
+++ b/src/glisten/tcp.gleam
@@ -39,6 +39,16 @@ pub fn receive(socket: Socket, length: Int) -> Result(BitArray, SocketReason)
 @external(erlang, "glisten_tcp_ffi", "unrecv")
 fn do_unrecv(socket: Socket, data: BitArray) -> Result(Nil, SocketReason)
 
+/// Peeks data from the given socket without consuming it, allowing the same data to be read in the future.
+/// This may be used for probing data from a bytestream, without impacting any processing that expects to read data directly from a socket.
+/// 
+/// USE WITH CAUTION:
+/// Callers expecting to repeatedly peek until a certain amount of data is buffered, *must not* call this function with a length value of 0.
+/// The data returned from a receive with length=0 immediately after a peek should not be considered all data currently available to read.
+/// 
+/// This is a wrapper around successive receive and unrecv call. This reads some data, and then immediately re-queues it for the next receive.
+/// This message cannot be appended with more data, and will likely behave unexpectedly with receive or peek calls intending to read all available data (parameter length value == 0).
+/// That is, the next receive call (implicit if peeking) after a peek, will return the exact same data as the last peek even if more data is available to read.
 pub fn peek_timeout(
   socket: Socket,
   length: Int,
@@ -48,6 +58,8 @@ pub fn peek_timeout(
   |> result.try(fn(msg) { do_unrecv(socket, msg) |> result.replace(msg) })
 }
 
+/// USE WITH CAUTION:
+/// See the docs for peek_timeout
 pub fn peek(socket: Socket, length: Int) -> Result(BitArray, SocketReason) {
   receive(socket, length)
   |> result.try(fn(msg) { do_unrecv(socket, msg) |> result.replace(msg) })

--- a/src/glisten/tcp.gleam
+++ b/src/glisten/tcp.gleam
@@ -36,7 +36,7 @@ pub fn receive_timeout(
 @external(erlang, "gen_tcp", "recv")
 pub fn receive(socket: Socket, length: Int) -> Result(BitArray, SocketReason)
 
-@external(erlang, "gen_tcp", "unrecv")
+@external(erlang, "glisten_tcp_ffi", "unrecv")
 fn do_unrecv(socket: Socket, data: BitArray) -> Result(Nil, SocketReason)
 
 pub fn peek_timeout(

--- a/src/glisten/tcp.gleam
+++ b/src/glisten/tcp.gleam
@@ -4,6 +4,7 @@ import gleam/dynamic.{type Dynamic}
 import gleam/erlang/atom.{type Atom}
 import gleam/erlang/process.{type Pid}
 import gleam/list
+import gleam/result
 import glisten/socket.{type ListenSocket, type Socket, type SocketReason}
 import glisten/socket/options.{type TcpOption}
 
@@ -34,6 +35,23 @@ pub fn receive_timeout(
 
 @external(erlang, "gen_tcp", "recv")
 pub fn receive(socket: Socket, length: Int) -> Result(BitArray, SocketReason)
+
+@external(erlang, "gen_tcp", "unrecv")
+fn do_unrecv(socket: Socket, data: BitArray) -> Result(Nil, SocketReason)
+
+pub fn peek_timeout(
+  socket: Socket,
+  length: Int,
+  timeout: Int,
+) -> Result(BitArray, SocketReason) {
+  receive_timeout(socket, length, timeout)
+  |> result.try(fn(msg) { do_unrecv(socket, msg) |> result.replace(msg) })
+}
+
+pub fn peek(socket: Socket, length: Int) -> Result(BitArray, SocketReason) {
+  receive(socket, length)
+  |> result.try(fn(msg) { do_unrecv(socket, msg) |> result.replace(msg) })
+}
 
 @external(erlang, "glisten_tcp_ffi", "send")
 pub fn send(socket: Socket, packet: BytesTree) -> Result(Nil, SocketReason)

--- a/src/glisten_tcp_ffi.erl
+++ b/src/glisten_tcp_ffi.erl
@@ -1,6 +1,6 @@
 -module(glisten_tcp_ffi).
 
--export([controlling_process/2, send/2, set_opts/2, shutdown/2, close/1, sockname/1, peername/1]).
+-export([controlling_process/2, send/2, set_opts/2, shutdown/2, close/1, sockname/1, peername/1, unrecv/2]).
 
 send(Socket, Packet) ->
   case gen_tcp:send(Socket, Packet) of
@@ -68,3 +68,11 @@ normalize_ip({A, B, C, D, E, F, G, H}) ->
   {ip_v6, A, B, C, D, E, F, G, H};
 normalize_ip({A, B, C, D}) ->
   {ip_v4, A, B, C, D}.
+
+unrecv(Socket, Data) ->
+  case gen_tcp:unrecv(Socket, Data) of
+    ok ->
+      {ok, nil};
+    {error, Reason} ->
+      {error, Reason}
+  end.

--- a/test/glisten_test.gleam
+++ b/test/glisten_test.gleam
@@ -27,7 +27,9 @@ pub fn it_echoes_messages_test() {
       let Nil = process.send(client_subject, Connected)
       let assert Ok(socket) = tcp.accept(listener)
       let loop = fn() {
-        let assert Ok(msg) = tcp.peek_timeout(socket, 0, 200)
+        let assert Ok(msg) = tcp.peek_timeout(socket, 2, 200)
+        process.send(client_subject, Response(msg))
+        let assert Ok(msg) = tcp.peek_timeout(socket, 6, 200)
         process.send(client_subject, Response(msg))
         let assert Ok(msg) = tcp.receive_timeout(socket, 0, 200)
         process.send(client_subject, Response(msg))
@@ -41,8 +43,11 @@ pub fn it_echoes_messages_test() {
   let assert Ok(_) =
     tcp.send(client, bytes_tree.from_bit_array(<<"hi mom":utf8>>))
 
-  let assert Ok(Response(peek_resp)) = process.receive(client_subject, 200)
-  assert peek_resp == <<"hi mom":utf8>>
+  let assert Ok(Response(peek_part)) = process.receive(client_subject, 200)
+  assert peek_part == <<"hi":utf8>>
+
+  let assert Ok(Response(peek_full)) = process.receive(client_subject, 200)
+  assert peek_full == <<"hi mom":utf8>>
 
   let assert Ok(Response(resp)) = process.receive(client_subject, 200)
   assert resp == <<"hi mom":utf8>>

--- a/test/glisten_test.gleam
+++ b/test/glisten_test.gleam
@@ -27,6 +27,8 @@ pub fn it_echoes_messages_test() {
       let Nil = process.send(client_subject, Connected)
       let assert Ok(socket) = tcp.accept(listener)
       let loop = fn() {
+        let assert Ok(msg) = tcp.peek_timeout(socket, 0, 200)
+        process.send(client_subject, Response(msg))
         let assert Ok(msg) = tcp.receive_timeout(socket, 0, 200)
         process.send(client_subject, Response(msg))
       }
@@ -38,8 +40,11 @@ pub fn it_echoes_messages_test() {
   let client = tcp_client.connect(54_321)
   let assert Ok(_) =
     tcp.send(client, bytes_tree.from_bit_array(<<"hi mom":utf8>>))
-  let assert Ok(Response(resp)) = process.receive(client_subject, 200)
 
+  let assert Ok(Response(peek_resp)) = process.receive(client_subject, 200)
+  assert peek_resp == <<"hi mom":utf8>>
+
+  let assert Ok(Response(resp)) = process.receive(client_subject, 200)
   assert resp == <<"hi mom":utf8>>
 }
 


### PR DESCRIPTION
For #50. Not the cleanest imo, but it works.

Major caveat: Not a true peek. Even if more data comes in between two peek calls with the second with len 0, or a peek and receive with len 0, you will only get whatever data you got with the first peek. So for example:

```gleam
// sock is a tcp socket with data "abcdef" pending

let assert Ok(peek1) = tcp.peek(sock, 2)
assert peek1 == "ab"

let assert Ok(peek_full) = tcp.peek(sock, 0)
assert peek_full == "abcdef"
```

fails because peek_full is still "ab". Quirk of `gen_tcp:unrecv`. Specifying an actual length in the second peek or receive works as expected though.